### PR TITLE
fixes tests typings

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,7 @@
 module.exports = {
-  moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
-  testMatch: ["<rootDir>*.spec.(js|jsx|ts|tsx)"],
+  preset: 'ts-jest',
   transform: {
-    "\\.graphql$": "jest-transform-graphql",
-    "\\.tsx?$": "ts-jest"
-  }
-};
+    '\\.ts$': 'ts-jest',
+    '\\.graphql$': 'jest-transform-graphql',
+  },
+}

--- a/shim.d.ts
+++ b/shim.d.ts
@@ -1,0 +1,1 @@
+declare module '*.graphql'

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,20 +3,14 @@
     "target": "esnext",
     "module": "esnext",
     "strict": true,
+    "noEmit": true, // so that it doesn't emit files in case you accidentally do not provide good config file
     "jsx": "preserve",
-    "importHelpers": true,
+    "importHelpers": false, // if you want this to be true, you'll need to add tslib as a dep.
     "moduleResolution": "node",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "sourceMap": true,
-    "baseUrl": ".",
-    "types": ["node", "jest"],
-    "paths": {
-      "@/*": ["src/*"]
-    },
     "lib": ["es2015", "dom", "dom.iterable", "scripthost", "es7", "esnext"]
-  },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules"]
+  }
 }


### PR DESCRIPTION
main missing thing was the `declare module '*.graphql'` which I put in `shims.d.ts`

big difference between previous ts-jest and 23.10 is that type chceking is now done by default

the `tsconfig.json` includes all your config plus `noEmit` and NO exclude/include, so that jest and your ide can report correctly errors/completion

the tsconfig.build.json is the one that should be used when building: `tsc -p tsconfig.build.json`